### PR TITLE
Update slip-10-xmr-recovery.py

### DIFF
--- a/python/slip-10-xmr-recovery.py
+++ b/python/slip-10-xmr-recovery.py
@@ -149,7 +149,7 @@ def get_keys(seedhex, derivationpath):
 
 
 def print_keys(derivation, mnemonic, passphrase = ""):
-    bip39_seed = Mnemonic("English").to_seed(mnemonic, passphrase)
+    bip39_seed = Mnemonic("english").to_seed(mnemonic, passphrase)
     pub, priv = get_keys(bip39_seed.hex(), parse_path(derivation))
     seed = monero.seed.Seed(priv.hex())
     pub_hex = '12' + seed.public_spend_key() + seed.public_view_key()


### PR DESCRIPTION
Lowercased "english" for 'mnemonic' package; capital "English" throws error because the wordlist filename is "english.txt" in mnemonic-0.20 (/home/[username]/.local/lib/python3.10/site-packages/mnemonic/wordlist/english.txt)